### PR TITLE
workaround for KeyError in the supported formats list

### DIFF
--- a/orpheusbetter
+++ b/orpheusbetter
@@ -42,6 +42,7 @@ def create_description(torrent, flac_dir, format, permalink):
     return description
 
 def formats_needed(group, torrent, supported_formats):
+    if '' in supported_formats: supported_formats.remove('')
     same_group = lambda t: t['media'] == torrent['media'] and\
                            t['remasterYear'] == torrent['remasterYear'] and\
                            t['remasterTitle'] == torrent['remasterTitle'] and\


### PR DESCRIPTION
Since some time (probably after disallowing V2 transcodes) Orpheus API returns a blank string in addition to the list of supported formats and it breaks the script. I've made a dumb but effective workaround to make it work again.