### PR TITLE
relax regex to ignore extra query params

### DIFF
--- a/whatapi.py
+++ b/whatapi.py
@@ -184,7 +184,7 @@ class WhatAPI:
         else:
             media_params = ['&media={0}'.format(media_search_map[m]) for m in media]
 
-        pattern = re.compile(r'reportsv2\.php\?action=report&amp;id=(\d+)".*?torrents\.php\?id=(\d+)"', re.MULTILINE | re.IGNORECASE | re.DOTALL)
+        pattern = re.compile(r'reportsv2\.php\?action=report&amp;id=(\d+)".*?torrents\.php\?id=(\d+).*?"', re.MULTILINE | re.IGNORECASE | re.DOTALL)
         if mode == 'snatched' or mode == 'both' or mode == 'all':
             url = '{0}/torrents.php?type=snatched&userid={1}&format=FLAC'.format(self.endpoint, self.userid)
             for mp in media_params:


### PR DESCRIPTION
searching for candidates currently fails because the candidate search regex is strict; it assumes that there is only a single query param called `id`. However, orp now returns search results whose URLs contain an additional query param. This PR fixes the problem with correctly identifying these returned search results by relaxing the regex pattern to account for the existence of additional query params.